### PR TITLE
Complete indie publishing redesign with dark mode

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,7 +24,7 @@
     </style>
 
 </head>
-    <body class="theme--midnight-copper">
+    <body class="theme--literary-folk">
     <div class="container">
         {% include header.html %}
 
@@ -32,6 +32,8 @@
             {{ content }}
         </main>
     </div>
+
+    <button class="theme-toggle" id="theme-toggle">Toggle Theme</button>
 
     <script type="module" src="{{ '/assets/js/main.js' | relative_url }}"></script>
     <script src="{{ '/assets/js/animations.js' | relative_url }}"></script>

--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -1,11 +1,13 @@
 .main-heading {
     font-family: 'Crimson Pro', serif;
-    font-size: clamp(56px, 12vw, 96px);
-    font-weight: 400;
-    line-height: 1.1;
-    margin-bottom: 40px;
-    letter-spacing: -0.03em;
+    font-size: clamp(72px, 14vw, 140px);
+    font-weight: 600;
+    line-height: 0.95;
+    margin-bottom: 30px;
+    letter-spacing: -0.04em;
     animation: fadeInUp 1s ease-out;
+    text-transform: none;
+    max-width: 900px;
 }
 
 .sub-heading {
@@ -19,13 +21,15 @@
 }
 
 .hero-description {
-    font-size: clamp(18px, 2.5vw, 20px);
-    line-height: 1.9;
-    color: var(--text-secondary);
-    font-weight: 300;
-    max-width: 750px;
-    margin: 0 auto 56px;
+    font-size: 16px;
+    line-height: 1.6;
+    color: var(--text-primary);
+    font-weight: 400;
+    max-width: 550px;
+    margin: 0 0 40px 0;
     animation: fadeInUp 1s ease-out 0.4s both;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
 }
 
 .hero-cta {

--- a/_sass/_themes.scss
+++ b/_sass/_themes.scss
@@ -74,3 +74,63 @@
     --border-color: rgba(139, 92, 72, 0.15);
     --shadow-color: rgba(139, 92, 72, 0.3);
 }
+
+// Option B: Dark Compassion (somber, psychological, intimate)
+.theme--dark-compassion {
+    --bg-primary: #1a1418;
+    --bg-secondary: rgba(26, 20, 24, 0.6);
+    --text-primary: #f0ebe8;
+    --text-secondary: #b8adb0;
+    --accent-primary: #9d7b8f;
+    --accent-secondary: #6b4f5e;
+    --accent-tertiary: #7a5968;
+    --gradient-start: rgba(157, 123, 143, 0.08);
+    --gradient-accent: rgba(157, 123, 143, 0.15);
+    --border-color: rgba(157, 123, 143, 0.2);
+    --shadow-color: rgba(157, 123, 143, 0.3);
+}
+
+// Option C: Brutalist Truth (stark, uncompromising, zero comfort)
+.theme--brutalist {
+    --bg-primary: #000000;
+    --bg-secondary: rgba(0, 0, 0, 0.8);
+    --text-primary: #ffffff;
+    --text-secondary: #b0b0b0;
+    --accent-primary: #ff4444;
+    --accent-secondary: #cc3333;
+    --accent-tertiary: #00d9ff;
+    --gradient-start: rgba(255, 68, 68, 0.05);
+    --gradient-accent: rgba(255, 68, 68, 0.1);
+    --border-color: rgba(255, 255, 255, 0.15);
+    --shadow-color: rgba(255, 68, 68, 0.4);
+}
+
+// Literary Folk (indie publishing, warm, illustrated, human)
+.theme--literary-folk {
+    --bg-primary: #ebe3d5;
+    --bg-secondary: rgba(235, 227, 213, 0.9);
+    --text-primary: #2a2520;
+    --text-secondary: #5a524a;
+    --accent-primary: #d64933;
+    --accent-secondary: #e8773d;
+    --accent-tertiary: #4a7c8c;
+    --gradient-start: rgba(214, 73, 51, 0.08);
+    --gradient-accent: rgba(214, 73, 51, 0.12);
+    --border-color: rgba(42, 37, 32, 0.15);
+    --shadow-color: rgba(214, 73, 51, 0.25);
+}
+
+// Literary Folk Dark (indie publishing night mode)
+.theme--literary-folk-dark {
+    --bg-primary: #1a1512;
+    --bg-secondary: rgba(26, 21, 18, 0.9);
+    --text-primary: #ebe3d5;
+    --text-secondary: #a8a098;
+    --accent-primary: #e8773d;
+    --accent-secondary: #d64933;
+    --accent-tertiary: #5a9cac;
+    --gradient-start: rgba(232, 119, 61, 0.08);
+    --gradient-accent: rgba(232, 119, 61, 0.12);
+    --border-color: rgba(235, 227, 213, 0.15);
+    --shadow-color: rgba(232, 119, 61, 0.25);
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -73,17 +73,19 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
     z-index: 2;
 }
 
-/* Hero Section */
+/* Hero Section - Editorial Style */
 .hero-section {
-    min-height: calc(100vh - 80px);
+    min-height: 70vh;
     display: flex;
     flex-direction: column;
     justify-content: center;
-    align-items: center;
-    text-align: center;
-    padding: 140px 40px;
+    align-items: flex-start;
+    text-align: left;
+    padding: 100px 60px 80px;
+    max-width: 1400px;
+    margin: 0 auto;
     position: relative;
-    overflow: hidden;
+    border-bottom: 3px solid var(--accent-primary);
 }
 
 .hero-section::before {
@@ -94,13 +96,10 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
     width: 200%;
     height: 200%;
     background: radial-gradient(circle, rgba(212, 165, 116, 0.03) 0%, transparent 70%);
-    animation: heroPulse 12s ease-in-out infinite;
     z-index: -1;
 }
 
 @keyframes heroPulse {
-    0%, 100% { transform: scale(1); opacity: 0.3; }
-    50% { transform: scale(1.05); opacity: 0.5; }
 }
 
 /* Animated Background Elements - Subtle */
@@ -135,13 +134,13 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
     color: var(--accent-primary);
     background: var(--gradient-accent);
     padding: 2px 8px;
-    border-radius: 4px;
+    border-radius: 12px;
     border-left: 2px solid var(--accent-primary);
 }
 
 /* Section Headers */
 .section-header {
-    text-align: center;
+    text-align: left;
     margin-bottom: 80px;
 }
 
@@ -163,106 +162,71 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
     font-weight: 300;
 }
 
-/* CTA Buttons */
+/* CTA Buttons - Indie Publishing Style */
 .cta-button {
     display: inline-block;
-    padding: 16px 32px;
-    border-radius: 8px;
+    padding: 14px 28px;
+    border-radius: 2px;
     text-decoration: none;
-    font-weight: 600;
-    font-size: 16px;
-    transition: all 0.3s ease;
-    border: 2px solid transparent;
-    margin: 8px;
+    font-weight: 500;
+    font-size: 15px;
+    transition: all 0.2s ease;
+    margin: 8px 8px 8px 0;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-family: 'Inter', sans-serif;
 }
 
 .cta-button.primary {
     background: var(--accent-primary);
     color: var(--bg-primary);
-    position: relative;
-    overflow: hidden;
-}
-
-.cta-button.primary::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: -100%;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.1), transparent);
-    transition: left 0.5s;
-}
-
-.cta-button.primary:hover::before {
-    left: 100%;
+    border: none;
 }
 
 .cta-button.primary:hover,
 .cta-button.primary:focus {
-    transform: translateY(-2px) scale(1.02);
-    background: var(--accent-secondary);
-    box-shadow: 0 10px 30px var(--shadow-color);
+    background: var(--text-primary);
     outline: none;
 }
 
 .cta-button.primary:focus-visible {
-    outline: 2px solid var(--accent-primary);
-    outline-offset: 4px;
+    outline: 3px solid var(--accent-primary);
+    outline-offset: 2px;
 }
 
 .cta-button.secondary {
     background: transparent;
     color: var(--accent-primary);
-    border-color: var(--accent-primary);
-    position: relative;
-    overflow: hidden;
-}
-
-.cta-button.secondary::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 0;
-    height: 100%;
-    background: var(--accent-primary);
-    transition: width 0.3s ease;
-    z-index: -1;
-}
-
-.cta-button.secondary:hover::before {
-    width: 100%;
+    border: 2px solid var(--accent-primary);
 }
 
 .cta-button.secondary:hover,
 .cta-button.secondary:focus {
+    background: var(--accent-primary);
     color: var(--bg-primary);
-    transform: translateY(-2px) scale(1.02);
-    box-shadow: 0 10px 30px var(--border-color);
     outline: none;
 }
 
 .cta-button.secondary:focus-visible {
-    outline: 2px solid var(--accent-primary);
-    outline-offset: 4px;
+    outline: 3px solid var(--accent-primary);
+    outline-offset: 2px;
 }
 
 .cta-button.large {
-    padding: 20px 40px;
-    font-size: 18px;
+    padding: 16px 36px;
+    font-size: 16px;
 }
 
 /* Problem Section */
 .problem-section {
-    padding: 140px 20px;
-    background: var(--bg-secondary);
+    padding: 80px 60px; max-width: 1400px; margin: 0 auto;
+    background: transparent;
 }
 
 .problem-content {
     max-width: 900px;
     margin: 0 auto;
-    text-align: center;
+    text-align: left;
 }
 
 .problem-content h2 {
@@ -306,7 +270,7 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 
 /* Framework Section */
 .framework-section {
-    padding: 140px 20px;
+    padding: 80px 60px; max-width: 1400px; margin: 0 auto;
     max-width: 1200px;
     margin: 0 auto;
 }
@@ -318,7 +282,7 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
     color: var(--text-primary);
     margin-bottom: 28px;
     letter-spacing: -0.02em;
-    text-align: center;
+    text-align: left;
 }
 
 .framework-intro {
@@ -327,7 +291,7 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
     color: var(--text-secondary);
     max-width: 850px;
     margin: 0 auto 80px;
-    text-align: center;
+    text-align: left;
     font-weight: 300;
 }
 
@@ -341,7 +305,7 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
     font-weight: 400;
     color: var(--text-primary);
     margin-bottom: 48px;
-    text-align: center;
+    text-align: left;
 }
 
 .methodology-grid {
@@ -352,17 +316,16 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 }
 
 .method-card {
-    background: rgba(42, 35, 30, 0.5);
-    border: 1px solid var(--border-color);
+    background: transparent;
+    border-left: 4px solid var(--accent-primary);
     border-radius: 12px;
     padding: 36px;
     transition: all 0.3s ease;
 }
 
 .method-card:hover {
-    transform: translateY(-4px);
     border-color: var(--border-color);
-    background: rgba(42, 35, 30, 0.7);
+    background: transparent;
 }
 
 .method-card h4 {
@@ -381,7 +344,7 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 
 .framework-status {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
     gap: 20px;
     margin: 60px 0;
@@ -391,7 +354,7 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 .framework-impact {
     max-width: 800px;
     margin: 0 auto;
-    text-align: center;
+    text-align: left;
 }
 
 .framework-impact h3 {
@@ -411,8 +374,8 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 
 /* Cooperative Section */
 .cooperative-section {
-    padding: 140px 20px;
-    background: var(--bg-secondary);
+    padding: 80px 60px; max-width: 1400px; margin: 0 auto;
+    background: transparent;
 }
 
 .cooperative-content {
@@ -427,7 +390,7 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
     color: var(--text-primary);
     margin-bottom: 32px;
     letter-spacing: -0.02em;
-    text-align: center;
+    text-align: left;
 }
 
 .cooperative-intro {
@@ -436,29 +399,28 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
     color: var(--text-secondary);
     max-width: 850px;
     margin: 0 auto 64px;
-    text-align: center;
+    text-align: left;
     font-weight: 300;
 }
 
 .cooperative-benefits {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(3, 1fr);
     gap: 40px;
     margin-bottom: 64px;
 }
 
 .benefit-card {
-    background: rgba(42, 35, 30, 0.5);
-    border: 1px solid var(--border-color);
+    background: transparent;
+    border-left: 4px solid var(--accent-primary);
     border-radius: 12px;
     padding: 40px;
     transition: all 0.3s ease;
 }
 
 .benefit-card:hover {
-    transform: translateY(-6px);
     border-color: var(--border-color);
-    background: rgba(42, 35, 30, 0.7);
+    background: transparent;
 }
 
 .benefit-card h3 {
@@ -479,14 +441,14 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
     font-size: clamp(20px, 3vw, 26px);
     line-height: 1.7;
     color: var(--accent-primary);
-    text-align: center;
+    text-align: left;
     font-weight: 400;
     font-style: italic;
 }
 
 /* Services Section */
 .services-section {
-    padding: 140px 20px;
+    padding: 80px 60px; max-width: 1400px; margin: 0 auto;
     max-width: 1200px;
     margin: 0 auto;
 }
@@ -499,11 +461,11 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 }
 
 .service-card {
-    background: rgba(42, 35, 30, 0.5);
-    border: 1px solid var(--border-color);
+    background: transparent;
+    border-left: 4px solid var(--accent-primary);
     border-radius: 12px;
     padding: 48px;
-    backdrop-filter: blur(10px);
+    
     position: relative;
     overflow: hidden;
     transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
@@ -526,13 +488,11 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 }
 
 .service-card:hover {
-    transform: translateY(-8px);
     border-color: var(--border-color);
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+    
 }
 
 .service-card:active {
-    transform: translateY(-4px);
 }
 
 .service-icon {
@@ -566,23 +526,22 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
     background: var(--border-color);
     color: var(--accent-primary);
     padding: 8px 16px;
-    border-radius: 20px;
+    border-radius: 12px;
     font-size: 13px;
     font-weight: 500;
-    border: 1px solid var(--border-color);
+    border-left: 4px solid var(--accent-primary);
     transition: all 0.3s ease;
 }
 
 .tag:hover {
     background: var(--border-color);
-    transform: translateY(-1px);
     border-color: var(--border-color);
 }
 
 /* Case Study Section */
 .case-study-section {
-    padding: 140px 20px;
-    background: var(--bg-secondary);
+    padding: 80px 60px; max-width: 1400px; margin: 0 auto;
+    background: transparent;
 }
 
 .case-study-content {
@@ -622,7 +581,7 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 }
 
 .phase {
-    background: rgba(42, 35, 30, 0.4);
+    background: transparent;
     border-radius: 12px;
     padding: 36px;
     border-left: 3px solid var(--accent-primary);
@@ -638,7 +597,7 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 
 .phase-number {
     display: inline-flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
     background: var(--accent-primary);
     color: #faf8f5;
@@ -653,7 +612,6 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 
 .phase:hover .phase-number {
     background: var(--accent-primary);
-    transform: scale(1.05);
 }
 
 .phase h4 {
@@ -673,7 +631,7 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 
 .case-study-status {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 16px;
     margin-top: 40px;
 }
@@ -682,7 +640,7 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
     background: var(--accent-primary);
     color: #faf8f5;
     padding: 10px 18px;
-    border-radius: 20px;
+    border-radius: 12px;
     font-size: 14px;
     font-weight: 500;
 }
@@ -695,33 +653,32 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 
 /* Team Section */
 .team-section {
-    padding: 140px 20px;
+    padding: 80px 60px; max-width: 1400px; margin: 0 auto;
     max-width: 1200px;
     margin: 0 auto;
 }
 
 .team-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: repeat(2, 1fr);
     gap: 40px;
     margin-top: 60px;
 }
 
 .team-member {
-    background: rgba(42, 35, 30, 0.5);
-    border: 1px solid var(--border-color);
+    background: transparent;
+    border-left: 4px solid var(--accent-primary);
     border-radius: 12px;
     padding: 40px;
     transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-    backdrop-filter: blur(10px);
+    
     position: relative;
 }
 
 .team-member:hover {
-    transform: translateY(-6px);
     border-color: var(--border-color);
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
-    background: rgba(42, 35, 30, 0.7);
+    
+    background: transparent;
 }
 
 .member-avatar {
@@ -731,7 +688,7 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
     background: var(--accent-primary);
     margin: 0 auto 24px;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
     font-size: 28px;
     color: #faf8f5;
@@ -741,7 +698,6 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 
 .team-member:hover .member-avatar {
     background: var(--accent-primary);
-    transform: scale(1.05);
 }
 
 .member-info h3 {
@@ -774,14 +730,14 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 
 /* Contact Section */
 .contact-section {
-    padding: 140px 20px;
-    background: var(--bg-secondary);
+    padding: 80px 60px; max-width: 1400px; margin: 0 auto;
+    background: transparent;
 }
 
 .contact-content {
     max-width: 800px;
     margin: 0 auto;
-    text-align: center;
+    text-align: left;
 }
 
 .contact-content h2 {
@@ -796,7 +752,7 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 .contact-value {
     max-width: 700px;
     margin: 0 auto 48px;
-    text-align: center;
+    text-align: left;
 }
 
 .contact-value p {
@@ -840,7 +796,7 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 .trust-indicators {
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: flex-start;
     gap: 40px;
     margin: 60px 0;
     flex-wrap: wrap;
@@ -848,19 +804,18 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 
 .trust-badge {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 12px;
     padding: 16px 24px;
-    background: rgba(42, 35, 30, 0.5);
-    border: 1px solid var(--border-color);
-    border-radius: 10px;
+    background: transparent;
+    border-left: 4px solid var(--accent-primary);
+    border-radius: 12px;
     transition: all 0.3s ease;
 }
 
 .trust-badge:hover {
-    transform: translateY(-2px);
     border-color: var(--border-color);
-    background: rgba(42, 35, 30, 0.7);
+    background: transparent;
 }
 
 .trust-icon {
@@ -884,18 +839,17 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 }
 
 .security-badge {
-    background: rgba(42, 35, 30, 0.5);
-    border: 1px solid var(--border-color);
-    border-radius: 10px;
+    background: transparent;
+    border-left: 4px solid var(--accent-primary);
+    border-radius: 12px;
     padding: 24px;
-    text-align: center;
+    text-align: left;
     transition: all 0.3s ease;
 }
 
 .security-badge:hover {
-    transform: translateY(-3px);
     border-color: var(--border-color);
-    background: rgba(42, 35, 30, 0.7);
+    background: transparent;
 }
 
 .security-badge-icon {
@@ -929,40 +883,32 @@ body::after {    content: "";    position: fixed;    top: 0;    left: 0;    widt
 }
 
 @keyframes float {
-    0%, 100% { transform: translateY(0px) rotate(0deg); }
-    50% { transform: translateY(-20px) rotate(2deg); }
 }
 
 @keyframes fadeInUp {
     from {
         opacity: 0;
-        transform: translateY(30px);
     }
     to {
         opacity: 1;
-        transform: translateY(0);
     }
 }
 
 @keyframes fadeInDown {
     from {
         opacity: 0;
-        transform: translateY(-30px);
     }
     to {
         opacity: 1;
-        transform: translateY(0);
     }
 }
 
 @keyframes slideDown {
     from {
         opacity: 0;
-        transform: translateY(-10px);
     }
     to {
         opacity: 1;
-        transform: translateY(0);
     }
 }
 
@@ -974,13 +920,11 @@ html {
 /* Scroll-triggered animations */
 .fade-in-up {
     opacity: 0;
-    transform: translateY(30px);
     transition: all 0.6s ease;
 }
 
 .fade-in-up.animate {
     opacity: 1;
-    transform: translateY(0);
 }
 
 .fade-in-left {
@@ -1007,13 +951,11 @@ html {
 
 .scale-in {
     opacity: 0;
-    transform: scale(0.8);
     transition: all 0.6s ease;
 }
 
 .scale-in.animate {
     opacity: 1;
-    transform: scale(1);
 }
 
 /* Parallax elements */
@@ -1045,13 +987,9 @@ html {
     .main-content {
         padding: 0 20px;
     }
-    
+
     .services-grid {
         grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    }
-    
-    .team-grid {
-        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     }
 }
 
@@ -1108,6 +1046,35 @@ html {
     .cta-button {
         display: block;
         margin: 8px 0;
-        text-align: center;
+        text-align: left;
     }
+}
+
+/* Theme Toggle Button */
+.theme-toggle {
+    position: fixed;
+    bottom: 40px;
+    right: 40px;
+    padding: 12px 24px;
+    background: var(--accent-primary);
+    color: var(--bg-primary);
+    border: none;
+    border-radius: 2px;
+    font-family: 'Inter', sans-serif;
+    font-size: 14px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    z-index: 1000;
+}
+
+.theme-toggle:hover {
+    background: var(--text-primary);
+}
+
+.theme-toggle:focus-visible {
+    outline: 3px solid var(--accent-primary);
+    outline-offset: 2px;
 }

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,50 +1,43 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const themeToggle = document.getElementById('themeToggle');
-    const themeIcon = themeToggle.querySelector('.theme-icon');
+    const themeToggle = document.getElementById('theme-toggle');
     const body = document.body;
-    
-    // Get saved theme or default to dark
-    const savedTheme = localStorage.getItem('theme') || 'default';
+
+    // Get saved theme or default to light
+    const savedTheme = localStorage.getItem('theme') || 'literary-folk';
     body.className = `theme--${savedTheme}`;
-    updateThemeIcon(savedTheme);
-    
+    updateButtonText(savedTheme);
+
     themeToggle.addEventListener('click', () => {
-        const currentTheme = body.classList.contains('theme--default') ? 'default' : 'light';
-        const newTheme = currentTheme === 'default' ? 'light' : 'default';
-        
+        const currentTheme = body.classList.contains('theme--literary-folk') ? 'literary-folk' : 'literary-folk-dark';
+        const newTheme = currentTheme === 'literary-folk' ? 'literary-folk-dark' : 'literary-folk';
+
         // Remove old theme class and add new one
-        body.classList.remove('theme--default', 'theme--light');
+        body.classList.remove('theme--literary-folk', 'theme--literary-folk-dark');
         body.classList.add(`theme--${newTheme}`);
-        
+
         // Save to localStorage
         localStorage.setItem('theme', newTheme);
-        
-        // Update icon
-        updateThemeIcon(newTheme);
-        
-        // Add a subtle animation
-        themeToggle.style.transform = 'scale(0.9)';
-        setTimeout(() => {
-            themeToggle.style.transform = 'scale(1)';
-        }, 150);
+
+        // Update button text
+        updateButtonText(newTheme);
     });
-    
-    function updateThemeIcon(theme) {
-        if (theme === 'light') {
-            themeIcon.textContent = '☀️';
+
+    function updateButtonText(theme) {
+        if (theme === 'literary-folk') {
+            themeToggle.textContent = 'Dark Mode';
         } else {
-            themeIcon.textContent = '🌙';
+            themeToggle.textContent = 'Light Mode';
         }
     }
-    
+
     // Listen for system theme changes
     if (window.matchMedia) {
         const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
         mediaQuery.addListener((e) => {
             if (!localStorage.getItem('theme')) {
-                const systemTheme = e.matches ? 'default' : 'light';
+                const systemTheme = e.matches ? 'literary-folk-dark' : 'literary-folk';
                 body.className = `theme--${systemTheme}`;
-                updateThemeIcon(systemTheme);
+                updateButtonText(systemTheme);
             }
         });
     }


### PR DESCRIPTION
## Typography & Layout Transformation
- Increase hero heading: 140px max, weight 600, line-height 0.95
- Make hero description small, uppercase with letter-spacing
- Change all layouts from centered to left-aligned
- Add editorial border-bottom to hero section
- Reduce section padding from 140px to 80px

## Visual Design Changes
- Remove all card backgrounds (transparent)
- Change borders to bold left borders (4px solid accent)
- Remove all box-shadows and transform effects
- Flatten sections to max-width 1400px containers
- Simplify border-radius throughout (12px standard)

## Button Redesign
- Remove gradient shine and fill effects
- Sharp corners (2px border-radius)
- Uppercase with letter-spacing for print feel
- Simple solid color transitions
- Primary hover: accent → dark brown
- Secondary hover: outline → filled

## Grid Layouts
- Team cards: 2x2 grid (balanced, egalitarian)
- Method cards: 3x1 + 1 asymmetric layout (editorial)
- Benefit cards: 3x1 grid (clean row)

## Dark Mode Implementation
- Add literary-folk-dark theme with inverted colors
- Dark brown background (#1a1512) with cream text
- Orange accent (#e8773d) for warmth
- Theme toggle button: fixed bottom-right, uppercase text
- Saves preference to localStorage
- Button text updates: "Dark Mode" / "Light Mode"

## Theme System
- Default theme: literary-folk (light, kraft paper aesthetic)
- Add brutalist and dark-compassion theme options
- CSS custom properties for instant switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)