### PR TITLE
fix(site): stop internal files leaking to the public site + Google index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,11 @@ reference_materials/
 .claude/
 .env
 .mcp.json
+
+# Superpowers brainstorm sessions
+.superpowers/
+
+# Internal working docs — never commit to the PUBLIC repo (white-paper sources,
+# third-party site feedback, etc.). The published white paper lives in assets/docs/.
+docs/*.pdf
+docs/*.docx

--- a/_config.yml
+++ b/_config.yml
@@ -30,10 +30,22 @@ sass:
   sass_dir: _sass
   style: compressed
 
+# Keep internal files out of the published site. Jekyll publishes EVERY top-level
+# file by default (anything not dot/underscore-prefixed or listed here), so each
+# internal file must be excluded explicitly or it becomes a public, indexable URL.
 exclude:
+  # Build tooling / dependency manifests
   - README.md
   - Gemfile
   - Gemfile.lock
+  - package.json
+  - babel.config.js
   - src/
   - vendor/
-  - docs/superpowers/   # engineering specs/plans; contain Liquid examples in code fences
+  # Internal only — AI/agent instructions, engineering notes, automation, raw data
+  - CLAUDE.md
+  - docs/                              # notes, specs, plans, source PDFs — never published
+  - check_feeds.py
+  - comprehensive_search.py
+  - search_regulations.py
+  - mental_health_ai_regulations_2025.json


### PR DESCRIPTION
## Problem
Jekyll publishes **every** top-level file by default (anything not dot/underscore-prefixed or in `exclude:`). Several internal files were therefore live and, in some cases, indexed by Google via `sitemap.xml`:

| URL | Status (live) | In sitemap? |
|---|---|---|
| `/docs/content-review/` and `/docs/content-review.md` | 200 — internal homepage-inventory note | ✅ indexed |
| `/CLAUDE/` | 200 — internal AI/tooling instructions | ✅ indexed |
| `/package.json`, `/check_feeds.py` (+ other scripts), regulations `.json` | 200 — directly fetchable | not in sitemap |

## Fix
- Broaden `_config.yml` `exclude:` from only `docs/superpowers/` to cover `docs/`, `CLAUDE.md`, `package.json`, `babel.config.js`, the three automation `.py` scripts, and the regulations `.json`.
- `.gitignore`: add `docs/*.pdf` / `docs/*.docx` so internal working docs (including the third-party site-feedback PDF) can't be committed to this **public** repo.

## Verification (local `bundle exec jekyll build`)
- All 8 internal paths absent from `_site/`.
- `sitemap.xml` clean — only real pages + the intended public white paper (`/assets/docs/Beyond_Accuracy_EIE_White_Paper.pdf`).
- All real pages (`/`, `/mission/`, `/privacy/`, `/regulations/`, `/sources/`, `/blog/`, `/admin/`) and the white paper still build. No regression.
- Pre-commit suite: 63/63 passing.

## Follow-up NOT handled by this PR (needs manual action after deploy)
Already-indexed URLs won't disappear on their own. Once merged and Pages rebuilds, `/docs/content-review/` and `/CLAUDE/` return 404 and drop from the sitemap. To remove them from Google promptly, use **Search Console → Removals → "Remove all URLs with this prefix"** for `/docs/` and `/CLAUDE/`. Do **not** add `Disallow:` to `robots.txt` for these — blocking the crawl prevents Google from seeing the 404, which keeps the stale entry indexed.

(Branch also carries two earlier commits: exclude `docs/superpowers/` and add root `favicon.ico`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)