### PR TITLE
fix(security): escape contact-form error output + harden CI workflow

### DIFF
--- a/.github/workflows/regulatory-monitor.yml
+++ b/.github/workflows/regulatory-monitor.yml
@@ -5,9 +5,11 @@ on:
   schedule:
     - cron: '0 9 * * 1'  # 9 AM UTC every Monday
   workflow_dispatch:  # Allow manual triggering
-  push:
-    branches:
-      - new-design  # Enable for testing on new-design branch
+
+# Least privilege: this workflow only reads the repo and opens issues.
+permissions:
+  contents: read
+  issues: write
 
 jobs:
   monitor-regulations:
@@ -15,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.11'
 
@@ -125,7 +127,7 @@ jobs:
 
       - name: Create issue if findings exist
         if: hashFiles('regulatory_findings.json') != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const fs = require('fs');

--- a/assets/js/contact-form.js
+++ b/assets/js/contact-form.js
@@ -75,10 +75,18 @@ function showErrorMessage(errors) {
         errorText = errors.map(e => e.message).join(', ');
     }
 
-    errorDiv.innerHTML = `
-        <div class="message-icon">✕</div>
-        <p><strong>Error:</strong> ${errorText}</p>
-    `;
+    // Build with DOM nodes + textContent so a server-supplied error string can
+    // never be interpreted as HTML (prevents DOM XSS via the response body).
+    const icon = document.createElement('div');
+    icon.className = 'message-icon';
+    icon.textContent = '✕';
+
+    const messageP = document.createElement('p');
+    const label = document.createElement('strong');
+    label.textContent = 'Error:';
+    messageP.append(label, ' ', errorText);
+
+    errorDiv.append(icon, messageP);
 
     form.insertBefore(errorDiv, form.firstChild);
 

--- a/assets/js/contact-form.test.js
+++ b/assets/js/contact-form.test.js
@@ -294,4 +294,29 @@ describe('Contact Form AJAX Handler', () => {
         expect(errorMessage).toBeTruthy();
         expect(errorMessage.textContent).toContain('Network error');
     });
+
+    test('error message renders server response as inert text, not HTML (XSS sink closed)', async () => {
+        const malicious = '<img src=x onerror="window.__xss = true">';
+        global.fetch.mockResolvedValue({
+            ok: false,
+            json: async () => ({ errors: malicious })
+        });
+
+        const { initContactForm } = await import('./contact-form.js');
+        initContactForm();
+
+        document.getElementById('name').value = 'Test User';
+        document.getElementById('email').value = 'test@example.com';
+        document.getElementById('message').value = 'Test message';
+
+        form.dispatchEvent(new Event('submit'));
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        const errorMessage = document.querySelector('.form-error');
+        expect(errorMessage).toBeTruthy();
+        // The markup must be inert: no element is parsed out of the response...
+        expect(errorMessage.querySelector('img')).toBeNull();
+        // ...and the raw string is shown to the user as text instead.
+        expect(errorMessage.textContent).toContain(malicious);
+    });
 });


### PR DESCRIPTION
Follow-up remediations from the full-site security review (separate from the docs-exposure fix in #15).

## 1. DOM XSS sink in the contact form — **Medium**
`assets/js/contact-form.js` built the error banner with `innerHTML` and interpolated the Formspree response body (`data.errors`) directly. A string like `<img src=x onerror=...>` in that response was parsed into a live element.

- **Fix:** rebuild the banner from DOM nodes and set the dynamic text via `textContent`, so a server-supplied string can never become markup.
- **Regression test added:** a malicious `errors` payload must produce no parsed `<img>` element and instead appear as inert text. Verified red→green (the old `innerHTML` code fails it; the fix passes).
- Suite: **64/64** passing.

## 2. CI workflow hardening — `regulatory-monitor.yml`
The workflow was **not** attacker-triggerable (schedule/`workflow_dispatch` only, no fork triggers, single-quoted Python heredoc). These are defense-in-depth:
- Add least-privilege `permissions: { contents: read, issues: write }` (was running at default token scope).
- Pin `actions/checkout`, `actions/setup-python`, `actions/github-script` to commit SHAs (were floating `@v4`/`@v5`/`@v7`).
- Remove the stale `push: [new-design]` test trigger.

## Not in this PR (needs your action)
- **Branch protection on `main`** — the CMS publishes straight to `main` with no review gate (Sveltia can't enforce `editorial_workflow`). This is the highest-value remaining control; settings provided separately.
- Verify the `auth.lonocollective.ai` OAuth app scope/redirect lockdown and repo collaborator list (off-repo, not reviewable from code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)